### PR TITLE
[data-tables] fix ReferenceError

### DIFF
--- a/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
+++ b/sdk/tables/data-tables/src/utils/isCosmosEndpoint.ts
@@ -19,7 +19,7 @@ export function isCosmosEndpoint(url: string): boolean {
     return false;
   }
 
-  const azuriteAccounts = process?.env?.AZURITE_ACCOUNTS?.split(":");
+  const azuriteAccounts = globalThis.process?.env?.AZURITE_ACCOUNTS?.split(":");
   if (azuriteAccounts?.[0] && parsedURL.hostname.includes(azuriteAccounts[0])) {
     return false;
   }


### PR DESCRIPTION
The issue is that in non-NodeJS environment `process` could be undefined, causing this error:

> ReferenceError: process is not defined

This PR updates it to use `globalThis.process`.

Fixes https://github.com/Azure/azure-sdk-for-js/issues/36567
